### PR TITLE
feat(nix): add buildGoModule and app outputs

### DIFF
--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -5,3 +5,9 @@ includes = ["*.nix"]
 [formatter.gofmt]
 command = "gofmt"
 includes = ["*.go"]
+
+[formatter.prettier]
+command = "prettier"
+options = ["--write", "--prose-wrap", "always", "--print-width", "80"]
+includes = ["*.md"]
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744440957,
+        "narHash": "sha256-FHlSkNqFmPxPJvy+6fNLaNeWnF1lZSgqVCl/eWaJRc4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "26d499fc9f1d567283d5d56fcf367edd815dba1d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}


### PR DESCRIPTION
- buildGoModule for packaging
- enables `nix run` to run the CLI directly
- future tags allow versioned usage like `nix run github:glwbr/juice/v0.1.0`